### PR TITLE
readme update: Serve docs after full build

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ If you find errors while executing `mkdocs serve` related to the `docs/api` and 
 To buid the entire doc site (only been test on Linux)
 1. Follow steps 1-3 above
 2. `./build.sh --venv <location of the venv you created in step 1 above>`
-3. Celebration!
+3. Run `mkdocs serve`
+4. Celebration!
 
 To build the API docs along with the general docs you should use build.sh
 


### PR DESCRIPTION
@thesteve0 is this accurate? I didn't know how to serve docs after full build with build.sh - since `mkdocs serve` will also build I thought.