### PR TITLE
References->API References; build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install and edit the general docs doc:
 ````
 2. Be in the root directory of the repo
 3. `pip install -r requirements.txt`
-4. Run `mkdocs serve --dirty`. The --dirty flag specifies that if you edit a single file, mkdocs serve will only rebuild that one file rather than the entire documentation site. To do a clean build and force mkdocs to build everything run `mkdocs server`. Clean is the default behavior.
+4. Run `mkdocs serve --dirty`. The --dirty flag specifies that if you edit a single file, mkdocs serve will only rebuild that one file rather than the entire documentation site. To do a clean build and force mkdocs to build everything run `mkdocs serve`. Clean is the default behavior.
 5.  PARTY!
 
 If you find errors while executing `mkdocs serve` related to the `docs/api` and `docs/ts_api` folders delete their symlinks and rerun the command. 

--- a/build.sh
+++ b/build.sh
@@ -27,54 +27,56 @@ VERSION="1.3"
 REPO_URL="https://github.com/voxel51/fiftyone.git"
 VENV_ACTIVATE="${HOME}/virtualenvs/vdoc-mkdocs/bin/activate"
 
-# Parse command line arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -h|--help)
-            show_usage
-            exit 0
-            ;;
-        -v|--verbose)
-            VERBOSE=1
-            set -x  # Enable bash debug mode
-            shift
-            ;;
-        --skip-clone)
-            SKIP_CLONE=1
-            shift
-            ;;
-        --version)
-            VERSION="$2"
-            shift 2
-            ;;
-        --repo-url)
-            REPO_URL="$2"
-            shift 2
-            ;;
-        --venv)
-            VENV_ACTIVATE="$2"
-            shift 2
-            ;;
-        --skip-python-api)
-            SKIP_PYTHON_API=1
-            shift
-            ;;
-        --skip-ts-api)
-            SKIP_TS_API=1
-            shift
-            ;;
-        --skip-all-api)
-            SKIP_PYTHON_API=1
-            SKIP_TS_API=1
-            shift
-            ;;
-        *)
-            log_error "Unknown option: $1"
-            show_usage
-            exit 1
-            ;;
-    esac
-done
+parse_args() {
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
+            -v|--verbose)
+                VERBOSE=1
+                set -x  # Enable bash debug mode
+                shift
+                ;;
+            --skip-clone)
+                SKIP_CLONE=1
+                shift
+                ;;
+            --version)
+                VERSION="$2"
+                shift 2
+                ;;
+            --repo-url)
+                REPO_URL="$2"
+                shift 2
+                ;;
+            --venv)
+                VENV_ACTIVATE="$2"
+                shift 2
+                ;;
+            --skip-python-api)
+                SKIP_PYTHON_API=1
+                shift
+                ;;
+            --skip-ts-api)
+                SKIP_TS_API=1
+                shift
+                ;;
+            --skip-all-api)
+                SKIP_PYTHON_API=1
+                SKIP_TS_API=1
+                shift
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+}
 
 # Logging functions
 log_info() {
@@ -157,8 +159,12 @@ check_dependencies() {
 # Function to check and activate virtual environment
 check_venv() {
     if [ ! -f "$VENV_ACTIVATE" ]; then
-        log_error "Virtual environment activation script not found at: $VENV_ACTIVATE"
-        exit 1
+        # Try again with /bin/activate
+        VENV_ACTIVATE="$VENV_ACTIVATE/bin/activate"
+        if [ ! -f "$VENV_ACTIVATE" ]; then
+            log_error "Virtual environment activation script not found at: $VENV_ACTIVATE"
+            exit 1
+        fi
     fi
     log_info "Activating virtual environment..."
     # shellcheck source=/dev/null
@@ -170,6 +176,8 @@ check_venv() {
 
 # Main execution starts here
 main() {
+    parse_args "$@"
+
     log_info "Starting documentation build process..."
 
     # Check and activate virtual environment

--- a/docs/api_references/index.md
+++ b/docs/api_references/index.md
@@ -1,0 +1,7 @@
+This page holds links to FiftyOne code reference material
+
+[Python API](../api/index.html) for navigating the functions, modules, and classes in the FiftyOne module
+
+[TypeScript API](../ts_api/index.html) for creating plugins, panels, and operators
+
+[Command Line Interface (CLI)](../cli/index.md) for FiftyOne

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -1,7 +1,0 @@
-This page just holds link to the various types of references
-
-[Python API](../api/index.html)
-
-[TypeScript API](../ts_api/index.html) for creating plugins, panels, and operators
-
-[CLI](../cli/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,8 +119,8 @@ nav:
       - Developing Plugins: plugins/developing_plugins.md
   - Integrations:
     - integrations/index.md
-  - References:
-      - references/index.md
+  - API References:
+      - api_references/index.md
       - Python API: api/index.html
       - TypeScript API: ts_api/index.html
       - CLI: cli/index.md


### PR DESCRIPTION
# API Reference change
Closes #43 

# Build.sh fixes
1. some functions were not defined before usage in arg parse. So put this in a function and call it from main(), then file structure can remain the same.
2. If user passes path to virtual env as instructed in README (and is more natural anyways), try to find `<YOUR_VENV>/bin/activate` before giving up.