### PR TITLE
refactor publishing workflows to enable PR previews for external contributors

### DIFF
--- a/.github/workflows/_clean_deployment.yml
+++ b/.github/workflows/_clean_deployment.yml
@@ -1,0 +1,42 @@
+name: Clean Docs Deployment
+
+on:
+  workflow_call:
+    inputs:
+      path:
+        type: string
+        required: true
+    secrets:
+      GCP_DOCS_PROJECT:
+        required: true
+      GCP_DOCS_SERVICE_ACCOUNT:
+        required: true
+      GOOGLE_WORKLOAD_IDP_SECRET_NAME:
+        required: true
+      GCP_DOCS_LOCATION:
+        required: true
+
+jobs:
+  clean-deployment:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      # we don't actually need the code, but google-github-actions/auth requires this for auth to work
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ secrets.GCP_DOCS_PROJECT }}
+          service_account: ${{ secrets.GCP_DOCS_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDP_SECRET_NAME }}
+
+      - name: Setup Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Clean up deployment
+        run: |
+          gsutil rm -r ${{ secrets.GCP_DOCS_LOCATION }}/${{ inputs.path }}

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -1,0 +1,67 @@
+name: Publish Voxel51 Docs
+
+on:
+  workflow_call:
+    inputs:
+      src-dir:
+        type: string
+        required: true
+      dest-dir:
+        type: string
+        required: false
+    secrets:
+      GCP_DOCS_PROJECT:
+        required: true
+      GCP_DOCS_SERVICE_ACCOUNT:
+        required: true
+      GOOGLE_WORKLOAD_IDP_SECRET_NAME:
+        required: true
+      GCP_DOCS_LOCATION:
+        required: true
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ secrets.GCP_DOCS_PROJECT }}
+          service_account: ${{ secrets.GCP_DOCS_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDP_SECRET_NAME }}
+
+      - name: Setup Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install python dependencies
+        run: |
+          python -m venv .venv && \
+          . .venv/bin/activate && \
+          pip install -r requirements.txt
+
+      - name: Install NPM dependencies
+        run: yarn install
+
+      - name: Build Docs
+        run: |
+          ./build.sh --venv ./.venv/bin/activate
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+
+      - name: Sync to bucket
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: ${{ inputs.src-dir }}
+          destination: ${{ secrets.GCP_DOCS_LOCATION }}/${{ inputs.dest-dir }}
+          parent: false

--- a/.github/workflows/clean-pr-preview.yml
+++ b/.github/workflows/clean-pr-preview.yml
@@ -1,0 +1,30 @@
+name: Clean PR preview
+
+on:
+  pull_request:
+    types:
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  clean-deployment:
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/_clean_deployment.yml
+    with:
+      path: pr-${{ github.event.number }}
+    secrets: inherit
+
+  update-pr-comment:
+    needs: clean-deployment
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            The preview for this PR has been removed

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,32 +10,50 @@ on:
 
 concurrency: preview-${{ github.ref }}
 
+env:
+  BUILT_DOCS_DIR: site/
+  PREVIEW_BASE_URL: https://beta-docs.dev.fiftyone.ai
+
 jobs:
   deploy-preview:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    if: ${{ github.event.action != 'closed' }}
+    permissions:
+      contents: read
+      id-token: write
+    id: publish
+    uses: ./.github/workflows/_publish.yml
+    with:
+      src-dir: ${{ env.BUILT_DOCS_DIR }}
+      dest-dir: pr-${{ github.event.number }}
+    secrets: inherit
 
-      - name: Install python dependencies
-        if: github.event.action != 'closed'
-        run: |
-          python -m venv .venv && \
-          . .venv/bin/activate && \
-          pip install -r requirements.txt
+  leave-pr-comment:
+    needs: publish
+    permissions:
+      pull-requests: write
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: pr-preview
+      message: |
+        View preview at <br> ${{ env.PREVIEW_BASE_URL }}/pr-${{ github.event.number }}/index.html <br>
 
-      - name: Install NPM dependencies
-        if: github.event.action != 'closed'
-        run: yarn install
+  clean-deployment:
+    if: ${{ github.event.action == 'closed' }}
+    permissions:
+      contents: read
+      id-token: write
+    id: clean-deployment
+    uses: ./.github/workflows/_clean_deployment.yml
+    with:
+      path: pr-${{ github.event.number }}
+    secrets: inherit
 
-      - name: Build Docs
-        if: github.event.action != 'closed'
-        run: |
-          ./build.sh --venv ./.venv/bin/activate
-        env:
-          NODE_OPTIONS: --max-old-space-size=4096
-
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
-        with:
-          source-dir: ./site/
+  update-pr-comment:
+    needs: clean-deployment
+    permissions:
+      pull-requests: write
+    uses: marocchino/sticky-pull-request-comment@v2
+    with:
+      header: pr-preview
+      message: |
+        The preview for this PR has been removed

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,12 +1,12 @@
-name: Deploy PR previews
+name: Deploy PR preview
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number'
+        type: number
+        required: true
 
 concurrency: preview-${{ github.ref }}
 
@@ -15,14 +15,13 @@ env:
 
 jobs:
   deploy-preview:
-    if: ${{ github.event.action != 'closed' }}
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/_publish.yml
     with:
       src-dir: site/
-      dest-dir: pr-${{ github.event.number }}
+      dest-dir: pr-${{ inputs.pr-number }}
     secrets: inherit
 
   leave-pr-comment:
@@ -34,27 +33,6 @@ jobs:
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-preview
+          number: ${{ inputs.pr-number }}
           message: |
-            View preview at <br> ${{ env.PREVIEW_BASE_URL }}/pr-${{ github.event.number }}/index.html <br>
-
-  clean-deployment:
-    if: ${{ github.event.action == 'closed' }}
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/_clean_deployment.yml
-    with:
-      path: pr-${{ github.event.number }}
-    secrets: inherit
-
-  update-pr-comment:
-    needs: clean-deployment
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: pr-preview
-          message: |
-            The preview for this PR has been removed
+            View preview at <br> ${{ env.PREVIEW_BASE_URL }}/pr-${{ inputs.pr-number }}/index.html <br>

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -11,7 +11,6 @@ on:
 concurrency: preview-${{ github.ref }}
 
 env:
-  BUILT_DOCS_DIR: site/
   PREVIEW_BASE_URL: https://beta-docs.dev.fiftyone.ai
 
 jobs:
@@ -22,7 +21,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/_publish.yml
     with:
-      src-dir: ${{ env.BUILT_DOCS_DIR }}
+      src-dir: site/
       dest-dir: pr-${{ github.event.number }}
     secrets: inherit
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           header: pr-preview
           message: |
-          View preview at <br> ${{ env.PREVIEW_BASE_URL }}/pr-${{ github.event.number }}/index.html <br>
+            View preview at <br> ${{ env.PREVIEW_BASE_URL }}/pr-${{ github.event.number }}/index.html <br>
 
   clean-deployment:
     if: ${{ github.event.action == 'closed' }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -29,13 +29,15 @@ jobs:
 
   leave-pr-comment:
     needs: publish
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    uses: marocchino/sticky-pull-request-comment@v2
-    with:
-      header: pr-preview
-      message: |
-        View preview at <br> ${{ env.PREVIEW_BASE_URL }}/pr-${{ github.event.number }}/index.html <br>
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+          View preview at <br> ${{ env.PREVIEW_BASE_URL }}/pr-${{ github.event.number }}/index.html <br>
 
   clean-deployment:
     if: ${{ github.event.action == 'closed' }}
@@ -50,10 +52,12 @@ jobs:
 
   update-pr-comment:
     needs: clean-deployment
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    uses: marocchino/sticky-pull-request-comment@v2
-    with:
-      header: pr-preview
-      message: |
-        The preview for this PR has been removed
+    steps:
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            The preview for this PR has been removed

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -11,7 +11,7 @@ on:
 concurrency: preview-${{ github.ref }}
 
 env:
-  PREVIEW_BASE_URL: https://beta-docs.dev.fiftyone.ai
+  PREVIEW_BASE_URL: https://beta-docs.voxel51.com
 
 jobs:
   deploy-preview:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    id: publish
     uses: ./.github/workflows/_publish.yml
     with:
       src-dir: ${{ env.BUILT_DOCS_DIR }}
@@ -28,7 +27,7 @@ jobs:
     secrets: inherit
 
   leave-pr-comment:
-    needs: publish
+    needs: deploy-preview
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -44,7 +43,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    id: clean-deployment
     uses: ./.github/workflows/_clean_deployment.yml
     with:
       path: pr-${{ github.event.number }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,6 @@ on:
       - README.md
       - .gitignore
 
-env:
-  BUILT_DOCS_DIR: site/
-
 jobs:
   publish-docs:
     permissions:
@@ -21,5 +18,5 @@ jobs:
       id-token: write
     uses: ./.github/workflows/_publish.yml
     with:
-      src-dir: ${{ env.BUILT_DOCS_DIR }}
+      src-dir: site/
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,45 +16,10 @@ env:
 
 jobs:
   publish-docs:
-    runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ secrets.GCP_DOCS_PROJECT }}
-          service_account: ${{ secrets.GCP_DOCS_SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDP_SECRET_NAME }}
-
-      - name: Set Up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install python dependencies
-        run: |
-          python -m venv .venv && \
-          . .venv/bin/activate && \
-          pip install -r requirements.txt
-
-      - name: Install NPM dependencies
-        run: yarn install
-
-      - name: Build Docs
-        run: |
-          ./build.sh --venv ./.venv/bin/activate
-        env:
-          NODE_OPTIONS: --max-old-space-size=4096
-
-      - name: Sync to bucket
-        uses: google-github-actions/upload-cloud-storage@v2
-        with:
-          path: ${{ env.BUILT_DOCS_DIR }}
-          destination: ${{ secrets.GCP_DOCS_LOCATION }}
-          parent: false
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/_publish.yml
+    with:
+      src-dir: ${{ env.BUILT_DOCS_DIR }}
+    secrets: inherit


### PR DESCRIPTION
This PR
* refactors the publishing workflow into a reusable workflow
* migrates from a gh-pages hosted PR preview to a self-hosted preview