### PR TITLE
chore: Previews when PRs are approved

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -17,6 +17,11 @@ jobs:
       (github.event_name == 'pull_request' && github.event.action == 'closed')
     runs-on: ubuntu-latest
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,27 +1,15 @@
 name: Deploy PR previews
 
 on:
-  pull_request:
-    types:
-      - closed
-
-  pull_request_review:
-    types: [submitted]
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
 
 concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
-    if: |
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
-      (github.event_name == 'pull_request' && github.event.action == 'closed')
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,15 +3,18 @@ name: Deploy PR previews
 on:
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
       - closed
+
+  pull_request_review:
+    types: [submitted]
 
 concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
+    if: |
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+      (github.event_name == 'pull_request' && github.event.action == 'closed')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
@findtopher found some cool stuff - https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/approving-workflow-runs-from-public-forks - it appears that we can utilize the `pull_request_target` target which will run in the context of the base branch permissions-wise. 

Workflows will the be queued for approval. When approved, they will run in the context of the base branch.

We can merge this and then I'll test the behavior with an account outside of the organization.