### PR TITLE
Revert "chore: Previews when PRs are approved (#75)"

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,8 +1,12 @@
 name: Deploy PR previews
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened, closed]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
 concurrency: preview-${{ github.ref }}
 


### PR DESCRIPTION
This reverts commit 8bfceba6ecde0b7a79ba38463b6f190439eb051d.

It appears that PRs are auto-triggering actions and they're now publishing.