### PR TITLE
chore(workflows/pre-commit): install extra libs so python installation is successful.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,8 +11,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.6
-      - uses: actions/setup-python@v5.2.0
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.4.0
+      - name: Temporary SQLite/LZMA - Install missing libraries
+        run: sudo apt install -y libsqlite3-dev libbz2-dev liblzma-dev libreadline-dev
       - name: install asdf & tools
         uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
# Rationale

While reviewing the pre-commit check run, I noticed that the asdf installation of python on the GitHub action runner was failing with:

```txt
Installing Python-3.11.11...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/.asdf/installs/python/3.11.11/lib/python3.11/bz2.py", line 17, in <module>
    from _bz2 import BZ2Compressor, BZ2Decompressor
ModuleNotFoundError: No module named '_bz2'
WARNING: The Python bz2 extension was not compiled. Missing the bzip2 lib?
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'readline'
WARNING: The Python readline extension was not compiled. Missing the GNU readline lib?
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/.asdf/installs/python/3.11.11/lib/python3.11/lzma.py", line 27, in <module>
    from _lzma import *
ModuleNotFoundError: No module named '_lzma'
WARNING: The Python lzma extension was not compiled. Missing the lzma lib?
Installed Python-3.11.11 to /home/runner/.asdf/installs/python/3.11.11
```

Let's add those extra packages so it will be successful.  (Its a good thing I already figured this out late last night).

## Changes

* install missing libs
* up other versions while we are here

## Testing

See this PR's checks

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
