### PR TITLE
build(previews): Add checkout ref for previews

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -4,15 +4,18 @@ name: Composite Publish Voxel51 Docs
 on:
   workflow_call:
     inputs:
-      src-dir:
-        type: string
-        required: true
-      secret-key:
-        type: string
-        required: true
       dest-dir:
         type: string
         required: false
+      secret-key:
+        type: string
+        required: true
+      src-dir:
+        type: string
+        required: true
+      src-ref:
+        type: string
+        required: true
     secrets:
       GCP_DOCS_PROJECT:
         required: true
@@ -34,7 +37,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
+        with:
+          ref: ${{ inputs.src-ref }}
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,3 +1,4 @@
+---
 name: Deploy PR preview
 
 on:
@@ -20,9 +21,10 @@ jobs:
       id-token: write
     uses: ./.github/workflows/_publish.yml
     with:
-      src-dir: site/
       dest-dir: pr-${{ inputs.pr-number }}
       secret-key: GCP_PREVIEW_DOCS_LOCATION
+      src-dir: site/
+      src-ref: refs/pull/${{ inputs.pr-number }}/head
     secrets: inherit
 
   leave-pr-comment:


### PR DESCRIPTION
# Rationale

Steve had an issue on https://github.com/voxel51/voxel51-docs/pull/87 where he couldn't see his changes in PR previews.
This PR adds the proper checkout references so that git checkouts happen from the pr branch, not main.

## Changes

Adds `${{ inputs.src-ref }}` as an input to composite actions. Built from `refs/pull/${{ inputs.pr-number }}/head`.
Small refactor to alpha-sort inputs.

## Testing

Tested in private repository.

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
