### PR TITLE
chore(asdf): AS-596 utilize asdf set and bump asdf action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Temporary SQLite/LZMA - Install missing libraries
         run: sudo apt install -y libsqlite3-dev libbz2-dev liblzma-dev libreadline-dev
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@1117842ea70e2711a0072e3a71265cbfe2c830be
+        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
       - uses: pre-commit/action@v3.0.1

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ asdf:  ## Update plugins, add plugins, install plugins, set local, reshim
 	@cat .tool-versions | xargs -I{} bash -c 'asdf install {}'
 
 	@echo "Setting local package versions..."
-	@cat .tool-versions | xargs -I{} bash -c 'asdf local {}'
+	@cat .tool-versions | xargs -I{} bash -c 'asdf set {}'
 
 	@echo "Reshimming.."
 	@asdf reshim


### PR DESCRIPTION
# Rationale

`asdf local` is deprecated and removed in newer versions. We can switch to `asdf set`. We can also bump to the newer action to avoid that deprecation notice which munges STDOUT.

## Changes

* Bump ASDF action to use the latest SHA
* Migrate from `asdf local` to `asdf set`

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
