### PR TITLE
Dark mode docs using custom colors #2

### DIFF
--- a/docs/_static/css/voxel51-docs.css
+++ b/docs/_static/css/voxel51-docs.css
@@ -23,8 +23,6 @@
 
   --voxel-bg-dark:                 rgb(29, 33, 37);
   --md-primary-fg-color:           rgba(255, 109, 4, 1);
-  /* --md-primary-fg-color--lighter:  rgba(255, 109, 4, 1); */
-  /* --md-default-fg-color--lighter:  rgba(255, 109, 4, 1); */
   --md-typeset-a-color:            rgb(255, 109, 4);
 }
 

--- a/docs/_static/css/voxel51-docs.css
+++ b/docs/_static/css/voxel51-docs.css
@@ -5,6 +5,8 @@
   --md-primary-fg-color:           rgba(255, 109, 4, 1);
   --md-primary-fg-color--light:    rgba(255, 109, 4, .7);
   --md-primary-fg-color--dark:     rgba(255, 109, 4, 1);
+  --md-primary-bg-color:           hsla(0, 0%, 100%, 1);
+  --md-primary-bg-color--light:    hsla(0, 0%, 100%, 0.7);
 
   --md-accent-fg-color:                rgba(255, 109, 4, 1);
   --md-accent-fg-color--transparent:   rgba(255, 109, 4, 0.1);

--- a/docs/_static/css/voxel51-docs.css
+++ b/docs/_static/css/voxel51-docs.css
@@ -1,17 +1,31 @@
-:root {
+:root > * {
   --md-text-font-family: 'Inter', sans-serif;
-
-  --voxel-bg-dark:                 rgb(29, 33, 37);
   --md-primary-fg-color:           rgba(255, 109, 4, 1);
   --md-primary-fg-color--light:    rgba(255, 109, 4, .7);
   --md-primary-fg-color--dark:     rgba(255, 109, 4, 1);
-  --md-primary-bg-color:           hsla(0, 0%, 100%, 1);
-  --md-primary-bg-color--light:    hsla(0, 0%, 100%, 0.7);
 
   --md-accent-fg-color:                rgba(255, 109, 4, 1);
   --md-accent-fg-color--transparent:   rgba(255, 109, 4, 0.1);
   --md-accent-bg-color:                rgba(255, 109, 4, 1);
   --md-accent-bg-color--light:         rgba(255, 109, 4, .7);
+
+  --md-typeset-a-color:                rgba(255, 109, 4, 1);
+  --md-default-fg-color--lighter:      rgba(255, 109, 4, 1);
+}
+
+/* Custom light mode */
+[data-md-color-scheme="custom"] {
+  --md-primary-fg-color:           rgba(255, 109, 4, 1);
+  }
+
+/* Custom dark mode, using slate and custom accent */
+[data-md-color-scheme="slate"][data-md-color-primary=indigo] {
+
+  --voxel-bg-dark:                 rgb(29, 33, 37);
+  --md-primary-fg-color:           rgba(255, 109, 4, 1);
+  /* --md-primary-fg-color--lighter:  rgba(255, 109, 4, 1); */
+  /* --md-default-fg-color--lighter:  rgba(255, 109, 4, 1); */
+  --md-typeset-a-color:            rgb(255, 109, 4);
 }
 
 @font-face {
@@ -76,4 +90,19 @@ html,body,h1,h2,h3,h4,h5,h6,p,div,a,form,button,input,select,textarea,sup,header
 
 .md-header__topic:first-child {
   font-weight: 300;
+}
+
+/* Controls color of annotation after opening */
+.md-tooltip--active+.md-annotation__index:after, :hover>.md-annotation__index:after {
+  --md-accent-fg-color: aqua;
+}
+
+/* Controls hover highlight color for hypertext */
+.md-typeset a:hover {
+  --md-accent-fg-color: aqua;
+}
+
+/* Controls highlight for tabbed content */
+.js .md-typeset .tabbed-labels:before {
+  background: rgba(255, 109, 4, 1);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,9 +3,20 @@ site_name: Voxel51 Documentation
 theme:
   name: material
   palette:
-    primary: custom
-    accent: custom
-  logo: _static/images/voxel51-logo-white.png
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  logo: _static/images/voxel51-logo-white-300.webp
   favicon: _static/images/icons/voxel51-166px.webp
   features:
     - navigation.path

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
-  logo: _static/images/voxel51-logo-white-300.webp
+  logo: _static/images/voxel51-logo-white.png
   favicon: _static/images/icons/voxel51-166px.webp
   features:
     - navigation.path


### PR DESCRIPTION
# Rationale

In PR #93, @Burhan-Q contributed a light and dark theme to the material-mkdocs. Given the recent merges, we needed to rebase this off the latest main.

Below is a copy/past from #93:

Fixes #24 adds dark mode and includes some additional color accents.

## Changes

- enables dark mode
- enables color change on hypertext hover using `#00ffff`
  - no objections to color choice being changed
  - also used for `hover` & `active` annotations (tool-tip) states
- uses brand color `#ff6d04` for tabbed content and annotations
- includes comments in CSS file for changes

## Testing

Built locally (see screenshots).

## Notes

Some images will likely need to be updated for better interoperability using dark mode (some of the logos on home page for instance).

<details><summary>Homepage logos with dark mode</summary>
<p>

![image](https://github.com/user-attachments/assets/0ff3211e-8112-456d-8ac8-964401976574)

</p>
</details> 

<!-- Optional Sections:

## To Do
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->

## Screenshots

<details><summary>Dark mode toggle</summary>
<p>

![image](https://github.com/user-attachments/assets/c9845ebb-0def-44f8-94d8-79090d97d871)

![image](https://github.com/user-attachments/assets/7523ec24-5f52-489a-abee-722e065107c0)

</p>
</details> 

<details><summary>Hypertext hover color</summary>
<p>

Currently hovering hypertext doesn't change text color

![image](https://github.com/user-attachments/assets/8ef43b5a-2dde-4af4-ae17-801da9a39774)

![image](https://github.com/user-attachments/assets/90b11db1-101d-4cb1-8485-88e646d610b5)

</p>
</details> 

<details><summary>Brand accent for annotations and tabs</summary>
<p>

When annotations and tabbed content are used, will now use `#ff6d04` as the default color

![image](https://github.com/user-attachments/assets/c43504da-93d0-4dd5-a37c-8272a2c7439a)

![image](https://github.com/user-attachments/assets/f0ead4e9-fba1-489f-a760-a41af11c2c19)

![image](https://github.com/user-attachments/assets/87ec32fa-c78b-493c-8f69-1e996c1b78d5)

![image](https://github.com/user-attachments/assets/9728cc65-6455-4827-801b-3955a1a5cb0f)

![image](https://github.com/user-attachments/assets/d44e4149-4fce-4d0f-9cf7-d7d560e32e79)

![image](https://github.com/user-attachments/assets/e910eeae-f515-446f-a190-bc67cf44ac4c)

</p>
</details> 


